### PR TITLE
Create .gitignore for the auto-generated configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Auto-generated configuration files.
+config.yml
+extensions.yml


### PR DESCRIPTION
This merge serves to prevent developers from accidentally checking-in configuration files, as they expose client details and are specific to the user anyway. Closes #5.