### PR TITLE
Add ruamel.yaml 0.16.10 to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pypresence==4.0.0
 ruamel.base==1.0.0
+ruamel.yaml==0.16.10


### PR DESCRIPTION
It needs ruamel.yaml 0.16.10 now, for some reason 😉 