### PR TITLE
Added double quotes around python executable directory

### DIFF
--- a/NotepadRPC.py
+++ b/NotepadRPC.py
@@ -18,7 +18,7 @@ except ModuleNotFoundError:
 if len(lib) > 0:
     print("Couldn't find required libraries. Trying to install them...")
     for each in lib:
-        response = os.system('{} -m pip install -U '.format(sys.executable) + each + " -q")
+        response = os.system('"{}" -m pip install -U '.format(sys.executable) + each + " -q")
         if response != 0:
             sys.exit("Couldn't install " + each)
     print("Successfully installed libraries.")


### PR DESCRIPTION
Installing libraries fails because C:\Program is seen as the command (or up until any space in the sys.executable path). Fixed by adding quotes around {}.

Reproduce the issue by uninstalling any of the libraries and running the program, provided that the path of your python executable has a space in it.